### PR TITLE
Small update

### DIFF
--- a/content/build-a-continuous-deployment-pipeline.md
+++ b/content/build-a-continuous-deployment-pipeline.md
@@ -115,9 +115,8 @@ it to authenticate with ECR and push an image into our repository.
 1. Expand the **Read** permissions and check the **BatchCheckLayerAvailability**
    and **GetAuthorizationToken** checkboxes.
 
-1. Expand the **Write** permissions and check the **CompleteLayerUpload**,
-   **UploadLayerPart**, **InitiateLayerUpload**, and *PutImage**
-   checkboxes.
+1. Expand the **Write** permissions and check the **CompleteLayerUpload**, 
+   **InitiateLayerUpload**, **PutImage**, and **UploadLayerPart** checkboxes.
 
 1. Click **Resources** to limit the role to the **workshop** repository.
 

--- a/content/create-a-docker-image-repository.md
+++ b/content/create-a-docker-image-repository.md
@@ -7,7 +7,7 @@ container images without worrying about managing or scaling the underlying
 infrastructure.
 
 Amazon ECR is integrated with Amazon ECS to simplify production deployment
-workshop and AWS IAM which provides provides resource-level control of each
+workshop and AWS IAM which provides resource-level control of each
 repository.
 
 We'll use this repository to store our Docker container images so that we can

--- a/content/create-a-service.md
+++ b/content/create-a-service.md
@@ -480,5 +480,11 @@ Load Balancer.
 
 🎉 You've completed this section!
 
+### Next
+
+✅  If you want to dive into CI/CD, try our next section, [Build a Continuous Deployment Pipeline][build-a-cd-pipeline], wherein we
+will use AWS CodeBuild to build our container and build a CI/CD pipeline with AWS CodePipeline to orchestrate the process and deploy it to ECS.
+
 [find-account-id]: https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html
 [create-an-alb]: #create-an-application-load-balancer
+[build-a-cd-pipeline]: build-a-continuous-deployment-pipeline.html

--- a/content/index.md
+++ b/content/index.md
@@ -31,7 +31,7 @@ configure a new service to run our container on Amazon ECS using AWS Fargate.
 
 The modules build on each other and are intended to be executed linearly.
 
-Ensure that you've followed the [setup guide][setup] before starting the modules.
+Ensure that you've followed the [setup guide][setup] before starting the following modules.
 
 | Module | Description |
 | ---------------- | -------------------------------------------------------- |

--- a/content/index.md
+++ b/content/index.md
@@ -31,6 +31,8 @@ configure a new service to run our container on Amazon ECS using AWS Fargate.
 
 The modules build on each other and are intended to be executed linearly.
 
+Ensure that you've followed the [setup guide][setup] before starting the modules.
+
 | Module | Description |
 | ---------------- | -------------------------------------------------------- |
 | [Getting Started with Amazon ECS using AWS Fargate][getting-started] | Create a new Amazon ECS cluster using the AWS Management Console. At the end of this module, we'll have a new ECS cluster and supporting infrastructure such as a VPC and subnets and a small Hello World application running. |


### PR DESCRIPTION
Hey, I have been able to go through the workshop in my account - great work! 

I have made a few suggestions and a fixed some wording/markdown.

I added a line to the top of your index page for users to go to the Setup first. I completely missed it when I started and dove right into the first module, only later did I realize that you had a link at the bottom so I added another one above the module listings.

Also, I added a 'Next' to the bottom of  build-a-continuous-deployment-pipeline.html to point to the CI/CD section. I missed that because I was used to the modules leading me from one to another and only when I went back to the index page days later did I realize there was an additional module in another section.